### PR TITLE
CI: super-linter - disable trivy and zizmor

### DIFF
--- a/.github/workflows/docker.image.yml
+++ b/.github/workflows/docker.image.yml
@@ -49,7 +49,9 @@ jobs:
         env:
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
           VALIDATE_RENOVATE: false
+          VALIDATE_TRIVY: false
   shiftleft:
     name: shiftleft
     strategy:


### PR DESCRIPTION
## Summary by Sourcery

Disable Zizmor and Trivy validations in the Docker image CI workflow

CI:
- Disable VALIDATE_GITHUB_ACTIONS_ZIZMOR validation
- Disable VALIDATE_TRIVY validation